### PR TITLE
AROS fixes

### DIFF
--- a/src/ppui/osinterface/sdl/SDL_ModalLoop.cpp
+++ b/src/ppui/osinterface/sdl/SDL_ModalLoop.cpp
@@ -101,10 +101,15 @@ PPModalDialog::ReturnCodes SDL_runModalLoop(PPScreen* screen, PPDialogBase* dial
 			{
 				// ignore old mouse motion events in the event queue
 				SDL_Event new_event;
-				
+#if defined(__AMIGA__) || defined(__AROS__) //SDL-1.2
+				if (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_EVENTMASK(SDL_MOUSEMOTION)) > 0)
+				{
+					while (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_EVENTMASK(SDL_MOUSEMOTION)) > 0);
+#else
 				if (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) > 0)
 				{
 					while (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) > 0);
+#endif
 					processSDLEvents(new_event);
 				} 
 				else 


### PR DESCRIPTION
differentiate between sdl versions used when calling this function, to avoid complaints about wrong number of arguments.